### PR TITLE
Fix broken Automation API link on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 
       <p>If you never want to write another System Security Plan or spend hours reading the NIST SP 800-53 again, get started with the <a href="https://github.com/GovReady/govready-q">GovReady-Q Compliance Server</a>, an open source project for techies who aren't FISMA experts.
 
-      </p>GovReady-Q Compliance Server simplifies and automates compliance for FISMA, the NIST Risk Management Framework, 800-53, and DFARS 800-171 (and more to come) with <a href="videos/demo/index.html">Compliance Apps</a> that map security controls to your technology stack, an <a href="https://github.com/GovReady/govready-q/blob/master/docs/Automation.md">Automation API</a> to update evidence and artifacts from live systems, and <a href="http://github.com/opencontrol">OpenControl repositories</a> that provide re-suable control implementation descriptions.
+      </p>GovReady-Q Compliance Server simplifies and automates compliance for FISMA, the NIST Risk Management Framework, 800-53, and DFARS 800-171 (and more to come) with <a href="videos/demo/index.html">Compliance Apps</a> that map security controls to your technology stack, an <a href="https://github.com/GovReady/govready-q/blob/master/docs/source/Automation.rst">Automation API</a> to update evidence and artifacts from live systems, and <a href="http://github.com/opencontrol">OpenControl repositories</a> that provide re-suable control implementation descriptions.
 
         <div class="row" style="border:0px solid blue;">
           <div class="col-md-4" style="text-align:center;">


### PR DESCRIPTION
Per commit a9f68c4, document source files changed from markdown to rst, which broke link to Automation API link (md file) on GovReady home page.